### PR TITLE
fix: ajuste login professores

### DIFF
--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,10 +1,10 @@
+// src/services/api.ts
 import axios from "axios";
 
 const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || "http://localhost:5000",
 });
 
-// Adiciona Authorization automaticamente se existir token
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem("token");
   if (token) {

--- a/web/src/services/auth.ts
+++ b/web/src/services/auth.ts
@@ -1,27 +1,36 @@
+// src/services/auth.ts
 import api from "./api";
 
-export async function registerTeacher(p: {name: string; email: string; password: string}) {
-  const { data } = await api.post("/api/professors/register", p);
-  return data; // {id,name,email,role}
+export async function registerTeacher(p: { name: string; email: string; password: string }) {
+  const body = { name: p.name.trim(), email: p.email.trim().toLowerCase(), password: p.password };
+  console.log("REGISTER_TEACHER_REQ", { ...body, password: `len=${body.password.length}` });
+  const { data } = await api.post("/api/professors/register", body);
+  return data;
 }
 
-export async function loginTeacher(p: {email: string; password: string}) {
-  const { data } = await api.post("/api/professors/login", p);
-  // { message, token, teacher: {...} }
+export async function loginTeacher(p: { email: string; password: string }) {
+  const body = { email: p.email.trim().toLowerCase(), password: p.password };
+  console.log("LOGIN_TEACHER_REQ", { ...body, password: `len=${body.password.length}` });
+  const { data } = await api.post("/api/professors/login", body);
   localStorage.setItem("token", data.token);
   localStorage.setItem("profile", JSON.stringify(data.teacher));
+  console.log("LOGIN_TEACHER_OK", { id: data.teacher?.id, role: data.teacher?.role });
   return data;
 }
 
-// Se seu backend tem endpoints de usuários (alunos):
-export async function registerStudent(p: {name: string; email: string; password: string}) {
-  const { data } = await api.post("/api/users/register", p);
+export async function registerStudent(p: { name: string; email: string; password: string }) {
+  const body = { name: p.name.trim(), email: p.email.trim().toLowerCase(), password: p.password };
+  console.log("REGISTER_STUDENT_REQ", { ...body, password: `len=${body.password.length}` });
+  const { data } = await api.post("/api/users/register", body);
   return data;
 }
 
-export async function loginStudent(p: {email: string; password: string}) {
-  const { data } = await api.post("/api/users/login", p);
+export async function loginStudent(p: { email: string; password: string }) {
+  const body = { email: p.email.trim().toLowerCase(), password: p.password };
+  console.log("LOGIN_STUDENT_REQ", { ...body, password: `len=${body.password.length}` });
+  const { data } = await api.post("/api/users/login", body);
   localStorage.setItem("token", data.token);
-  localStorage.setItem("profile", JSON.stringify(data.user || data.student || data.teacher || {}));
+  localStorage.setItem("profile", JSON.stringify(data.user || data.student || {}));
+  console.log("LOGIN_STUDENT_OK", { id: data.user?.id, role: data.user?.role });
   return data;
 }


### PR DESCRIPTION
**Ajustado LoginScreen para usar o endpoint correto:**
POST /api/professors/login para professores
POST /api/users/login para estudantes
Normalização de e-mail (trim + lowercase) antes do envio.
Correção do envio do body de login (não manda mais userType para o back).
Salvando corretamente token no localStorage e profile de acordo com a resposta da API.
Validação de formulário reforçada (não permite submit sem tipo de usuário, e-mail ou senha).
Correção do redirecionamento após login bem sucedido (navigate("/dashboard")).


 **Problemas resolvidos**
Antes, todos os logins usavam /api/users/login, o que fazia com que professores recebessem “senha inválida” mesmo com credenciais corretas.
Erro de sincronização entre o que funcionava no Postman e o que funcionava na aplicação.